### PR TITLE
Issue14 preserve enrollment login changes

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -28,6 +28,7 @@ from django.contrib.auth.hashers import make_password
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.db import models, IntegrityError, transaction
 from django.db.models import Count
+from django.db.models.signals import pre_save
 from django.dispatch import receiver, Signal
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext_noop
@@ -1413,6 +1414,15 @@ def enforce_single_login(sender, request, user, signal, **kwargs):    # pylint: 
         else:
             key = None
         user.profile.set_login_session(key)
+
+
+## make email domain case insensitive
+@receiver(pre_save, sender=User)
+def User_pre_save(sender, instance, *args, **kwargs):
+    email = instance.email
+    if email:
+        uname, domain = email.split('@')
+        instance.email = '@'.join([uname,domain.lower()])
 
 
 class DashboardConfiguration(ConfigurationModel):

--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -2,6 +2,7 @@
 
 import ddt
 import unittest
+from django.contrib.auth import get_user
 from django.contrib.auth.models import User
 from django.test.client import RequestFactory
 from django.conf import settings
@@ -97,6 +98,15 @@ class TestCreateAccount(TestCase):
         settings.FEATURES['BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH']=False and doing external auth
         """
         self.base_extauth_bypass_sending_activation_email(False)
+
+    def test_not_logged_in_after_create(self):
+        """
+        Test user not automatically logged in after user creation
+        """
+        response = self.client.post(self.url, self.params)
+        self.assertEqual(response.status_code, 200)
+        user = get_user(self.client)
+        self.assertTrue(user.is_anonymous())
 
 
 @mock.patch.dict("student.models.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -184,16 +184,13 @@ def _has_access_course_desc(user, action, course):
         course is not invitation only.
         """
 
-        # if using registration method to restrict (say shibboleth)
-        if settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
-            if user is not None and user.is_authenticated() and \
-                    ExternalAuthMap.objects.filter(user=user, external_domain=course.enrollment_domain):
-                debug("Allow: external_auth of " + course.enrollment_domain)
-                reg_method_ok = True
+        if course.enrollment_domain:
+            if user is not None and hasattr(user, 'email'):
+                reg_method_ok = user and user.email.lower().endswith('@' + course.enrollment_domain.lower())
             else:
                 reg_method_ok = False
         else:
-            reg_method_ok = True  # if not using this access check, it's always OK.
+            reg_method_ok = True
 
         now = datetime.now(UTC())
         start = course.enrollment_start or datetime.min.replace(tzinfo=pytz.UTC)


### PR DESCRIPTION
Merge fixes for Issue 14 (preserve enrollment login changes... user emails to lowercase, case insensitive check of student email domain against course enrollment domain, don't automatically log in new users upon registration)
